### PR TITLE
Rewrite existing Workspace docs, make compatible with dumpling

### DIFF
--- a/Instances/Workspace/FindPartOnRay.md
+++ b/Instances/Workspace/FindPartOnRay.md
@@ -4,21 +4,21 @@ description = "Find's the first base part on the given ray."
 related = ["Workspace.FindPartOnRayWithIgnoreList"]
 +++
 
-FindPartOnRay uses raycasting to find the first BasePart intersecting with a given Ray. This function returns the position of intersection, the surface normal of the intersecting BasePart at the point of intersection, and the BasePart's BasePart.Material.
+Find the first `BasePart` intersecting with the given `Ray` at the point closest to the ray's origin.
+
+The ray will not hit backfaces of parts. If the ray originates from inside a typical part it will never hit that part, with the exception of non-convex parts like Terrain and MeshParts with CollisionFidelity.Default.
+
+The length of the direction vector matters, and is clamped to a maximum of 5000 studs.
+
+Returns multiple values:
+
+- The part that was hit
+- The world space position of intersection
+- The world space surface normal of the part at the point of intersection
+- `BasePart.Material` for most `BaseParts`, or the voxel material at the point of intersection for `Terrain`.
+
+If the ray doesn't hit anything the return values will be:
 
 ```lua
-local character = game.Players.LocalPlayer.Character
-local head = character:FindFirstChild("Head")
-
-local origin = head.Position
-local lookDirection = head.CFrame.lookVector
-local ray = Ray.new(origin, lookDirection * 500)
-
-local part, hitPosition = workspace:FindPartOnRay(ray, character)
-
-if part then
-	print("Hit part: " .. part:GetFullName())
-else
-	print("Did not hit part")
-end
+nil, ray.Origin + ray.Direction, Vector3.new(), Enum.Material.Air
 ```

--- a/Instances/Workspace/FindPartOnRay.md
+++ b/Instances/Workspace/FindPartOnRay.md
@@ -1,4 +1,5 @@
 +++
+target = "Workspace.FindPartOnRay"
 description = "Find's the first base part on the given ray."
 related = ["Workspace.FindPartOnRayWithIgnoreList"]
 +++

--- a/Instances/Workspace/FindPartOnRay.md
+++ b/Instances/Workspace/FindPartOnRay.md
@@ -1,6 +1,6 @@
 +++
 target = "Workspace.FindPartOnRay"
-description = "Find's the first base part on the given ray."
+description = "Finds the first BasePart along the given ray."
 related = ["Workspace.FindPartOnRayWithIgnoreList"]
 +++
 

--- a/Instances/Workspace/FindPartOnRay.md
+++ b/Instances/Workspace/FindPartOnRay.md
@@ -1,7 +1,7 @@
 +++
-target = "Workspace.FindPartOnRay"
-description = "Finds the first BasePart along the given ray."
-related = ["Workspace.FindPartOnRayWithIgnoreList"]
+Target = "Workspace.FindPartOnRay"
+Description = "Finds the first BasePart along the given ray."
+Related = ["Workspace.FindPartOnRayWithIgnoreList"]
 +++
 
 Find the first `BasePart` intersecting with the given `Ray` at the point closest to the ray's origin.

--- a/Instances/Workspace/FindPartOnRay.md
+++ b/Instances/Workspace/FindPartOnRay.md
@@ -1,8 +1,7 @@
----
-Description: Find's the first base part on the given ray.
-Related: 
-- Instance/Workspace/FindPartOnRayWithIgnoreList
----
++++
+description = "Find's the first base part on the given ray."
+related = ["Workspace.FindPartOnRayWithIgnoreList"]
++++
 
 FindPartOnRay uses raycasting to find the first BasePart intersecting with a given Ray. This function returns the position of intersection, the surface normal of the intersecting BasePart at the point of intersection, and the BasePart's BasePart.Material.
 

--- a/Instances/Workspace/Workspace.md
+++ b/Instances/Workspace/Workspace.md
@@ -3,4 +3,8 @@ target = "Workspace"
 description = "The Workspace is the service in which any objects that are to be rendered in the 3D world exist."
 +++
 
-The Workspace is the service in which any objects that are to be rendered in the 3D world exist. Objects not descending from Workspace will not be rendered or physically interact with the world.
+The Workspace is a Service containing the replicated, simulated world.
+
+Objects descending from workspace will be rendered and physically interact.
+
+Workspace is the root of the physical world. Parts, joints, and Constraints will not function unless they are in Workspace.

--- a/Instances/Workspace/Workspace.md
+++ b/Instances/Workspace/Workspace.md
@@ -1,6 +1,5 @@
 +++
 target = "Workspace"
-description = "The Workspace is the service in which any objects that are to be rendered in the 3D world exist."
 +++
 
 The Workspace is a Service containing the replicated, simulated world.

--- a/Instances/Workspace/Workspace.md
+++ b/Instances/Workspace/Workspace.md
@@ -1,5 +1,5 @@
----
-Description: "The Workspace is the service in which any objects that are to be rendered in the 3D world exist."
-Related:
----
++++
+description = "The Workspace is the service in which any objects that are to be rendered in the 3D world exist."
++++
+
 The Workspace is the service in which any objects that are to be rendered in the 3D world exist. Objects not descending from Workspace will not be rendered or physically interact with the world.

--- a/Instances/Workspace/Workspace.md
+++ b/Instances/Workspace/Workspace.md
@@ -1,5 +1,5 @@
 +++
-target = "Workspace"
+Target = "Workspace"
 +++
 
 The Workspace is a Service containing the replicated, simulated world.

--- a/Instances/Workspace/Workspace.md
+++ b/Instances/Workspace/Workspace.md
@@ -1,4 +1,5 @@
 +++
+target = "Workspace"
 description = "The Workspace is the service in which any objects that are to be rendered in the 3D world exist."
 +++
 


### PR DESCRIPTION
Updated the front matter to use the toml front matter format used by dumpling.

Combined workspace files.

Rewrote contents of the one file that had any documentation. Attempted to add more details and distinguish it from just being a copy of the devhub docs. We should be able to do better.

PR instead of submitting directly because I'm unsure how we actually want to structure these files longer term. Dumpling at least doesn't enforce any kind of file structure. Soft preference for keeping docs for the same class in the same file but could go either way.